### PR TITLE
Make the code py3 compatible

### DIFF
--- a/MUSCL_1D_example.py
+++ b/MUSCL_1D_example.py
@@ -26,6 +26,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 '''
 
+from __future__ import division, print_function
 import numpy
 import matplotlib.pyplot as plt
 
@@ -125,7 +126,7 @@ def main():
             
             S = numpy.maximum(S,B)                                              # Eq. 7
         
-            print 'MUSCL Year %d, dt_use %f' % (t,dt_use)
+            print('MUSCL Year %d, dt_use %f' % (t,dt_use))
     
     
         if numpy.mod(t,1000.)==0.0:
@@ -172,7 +173,7 @@ def main():
             
             S = numpy.maximum(S,B)    
         
-            print 'Upstream Year %d, dt_use %f' % (t,dt_use)
+            print('Upstream Year %d, dt_use %f' % (t,dt_use))
     
     
         if numpy.mod(t,1000.)==0.0:
@@ -208,7 +209,7 @@ def main():
             
             S = numpy.maximum(S,B)    
         
-            print 'M2 Year %d, dt_use %f' % (t,dt_use)
+            print('M2 Year %d, dt_use %f' % (t,dt_use))
     
     
         if numpy.mod(t,1000.)==0.0:
@@ -234,13 +235,13 @@ def main():
     vol_err_upstream = (vol_upstream-vol_exact)/vol_exact*100
     vol_err_M2 = (vol_M2-vol_exact)/vol_exact*100
     
-    print "vol exact: %e" % vol_exact
-    print "vol muscl: %e" % vol_muscl
-    print "vol upstream: %e" % vol_upstream
-    print "vol M2: %e" % vol_M2
-    print "err muscl %0.3f" % vol_err_muscl
-    print "err upstream: %0.3f" % vol_err_upstream
-    print "err M2 %0.3f" % vol_err_M2
+    print("vol exact: %e" % vol_exact)
+    print("vol muscl: %e" % vol_muscl)
+    print("vol upstream: %e" % vol_upstream)
+    print("vol M2: %e" % vol_M2)
+    print("err muscl %0.3f" % vol_err_muscl)
+    print("err upstream: %0.3f" % vol_err_upstream)
+    print("err M2 %0.3f" % vol_err_M2)
     
     p4, = plt.plot(x/1000,B,'-k',linewidth=2)
     p5, = plt.plot(x/1000,s,'-',linewidth=3,color='#ff7800')

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # sia-fluxlim
-Implementation of a MUSCL flux limiter to a shallow ice approximation flow code based on finite differences.
+
+A python implementation of a MUSCL flux limiter to a shallow ice approximation flow code based on finite differences.
 
 For an overview of possible flux limiter functions (phi) to the MUSCL scheme, see [Wikipedia - flux limiter](https://en.wikipedia.org/wiki/Flux_limiter).
 I have implemented now the Sweby (1984) limiter, which uses a parameter called 'beta'. For 1 <= beta <= 2 the limiter is second order TVD and its end members are equal to the limiter discussed in the paper below. If beta = 1, the Sweby limiter is equal to Roe's minmod limiter and if beta = 2 one gets Roe's superbee limiter. 
 
-For more details such as the scientific argument as to why this is a good idea, please consult the acompaning publication by **A. H. Jarosch**, C. G. Schoof, and F. S. Anslow, "[Restoring mass conservation to shallow ice flow models over complex terrain](http://www.the-cryosphere.net/7/229/2013/tc-7-229-2013.html),” *The Cryosphere*, Vol. 7, Iss. 1, pp. 229-240, 2013.
+For more details such as the scientific argument as to why this is a good idea, please consult the accompanying publication by **A. H. Jarosch**, C. G. Schoof, and F. S. Anslow, "[Restoring mass conservation to shallow ice flow models over complex terrain](http://www.the-cryosphere.net/7/229/2013/tc-7-229-2013.html),” *The Cryosphere*, Vol. 7, Iss. 1, pp. 229-240, 2013.

--- a/SIA_2D_BuelerC.py
+++ b/SIA_2D_BuelerC.py
@@ -32,6 +32,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 '''
 
+from __future__ import division, print_function
 import numpy
 import matplotlib.pyplot as plt
 import time
@@ -96,7 +97,7 @@ def main():
             S = S + (M_dot + div_q)*dt_use
             S = numpy.maximum(S,B)
             
-            print 't[year]: %04.3f, dt_use[days]: %.04f' % (t_pass+cfl_t, dt_use*365)
+            print('t[year]: %04.3f, dt_use[days]: %.04f' % (t_pass+cfl_t, dt_use*365))
          
         # check for mass conservation
         H_step = S - B
@@ -105,13 +106,13 @@ def main():
         I_H[H_step>0] = 1
         M_step = M_dot*I_H
         M_vol = M_vol + numpy.sum(M_step)*dx*dy
-        print "t[year]: %.1f current ice volume %.4f" % (t_pass+cfl_t, Vol_step)
-        print "t[year]: %.1f current MB volume %.4f" % (t_pass+cfl_t, M_vol)
-        print "t[year]: %.1f Mass %.11f qm" % (t_pass+cfl_t, Vol_step-M_vol)
+        print("t[year]: %.1f current ice volume %.4f" % (t_pass+cfl_t, Vol_step))
+        print("t[year]: %.1f current MB volume %.4f" % (t_pass+cfl_t, M_vol))
+        print("t[year]: %.1f Mass %.11f qm" % (t_pass+cfl_t, Vol_step-M_vol))
                                                         
     # print timing
     t_needed = (time.time() - tstart)
-    print "it took: " + str(t_needed) + " seconds to solve the problem ;)"
+    print("it took: " + str(t_needed) + " seconds to solve the problem ;)")
     
     # Display the final result
     plt.figure()
@@ -138,8 +139,8 @@ def main():
     err = (Vol_final-Vol_exact)/Vol_exact*100
     err_abs = (Vol_final-Vol_exact_abs)/Vol_exact_abs*100
     
-    print 'The cumulative numerical error is %f percent' % err
-    print 'The cumulative absolute error is %f percent' % err_abs
+    print('The cumulative numerical error is %f percent' % err)
+    print('The cumulative absolute error is %f percent' % err_abs)
 
     plt.show()     
         


### PR DESCRIPTION
Thanks for sharing!  This is very useful.

This trivial PR makes the code run on py3 *and* py2. I assume all your operations are floating point anyway, but I just tested it under py3 and everything works fine:
![figure_1](https://cloud.githubusercontent.com/assets/10050469/26112896/62580db6-3a59-11e7-9472-b93ce10580a4.png)

![figure_1-1](https://cloud.githubusercontent.com/assets/10050469/26112902/664e91b0-3a59-11e7-92ff-24ce84de6bff.png)

![figure_2](https://cloud.githubusercontent.com/assets/10050469/26112906/68286b96-3a59-11e7-973d-15d2f9fa04c5.png)


